### PR TITLE
Use spec operatorId as tool_name

### DIFF
--- a/ansible_mcp_tools/authentication/validators/aap_nop_validator.py
+++ b/ansible_mcp_tools/authentication/validators/aap_nop_validator.py
@@ -19,11 +19,9 @@ logger = get_logger(__name__)
 
 
 class AAPNopValidator(AuthenticationValidator):
-
     async def validate(
         self, connection: HTTPConnection
     ) -> tuple[AuthCredentials, BaseUser] | None:
-
         auth_user = AuthenticationUser(
             "nop",
             AuthenticationInfo(

--- a/ansible_mcp_tools/openapi/protocols/spec_loader.py
+++ b/ansible_mcp_tools/openapi/protocols/spec_loader.py
@@ -4,7 +4,6 @@ from typing import Protocol, runtime_checkable
 
 @runtime_checkable
 class SpecLoader(Protocol):
-
     def fetch(self) -> str: ...
 
     def load(self) -> Dict: ...

--- a/ansible_mcp_tools/openapi/protocols/tool_caller.py
+++ b/ansible_mcp_tools/openapi/protocols/tool_caller.py
@@ -7,7 +7,6 @@ from typing import Protocol, runtime_checkable
 
 @runtime_checkable
 class ToolCaller(Protocol):
-
     async def tool_call(
         self, name: str, arguments: Dict
     ) -> List[types.TextContent]: ...

--- a/ansible_mcp_tools/openapi/protocols/tool_name_strategy.py
+++ b/ansible_mcp_tools/openapi/protocols/tool_name_strategy.py
@@ -3,7 +3,6 @@ from typing import Protocol, runtime_checkable
 
 @runtime_checkable
 class ToolNameStrategy(Protocol):
-
     def normalize_tool_name(self, raw_name: str) -> str: ...
 
     def normalize_tool_parameter_name(self, raw_name: str) -> str: ...

--- a/ansible_mcp_tools/openapi/protocols/tool_parser.py
+++ b/ansible_mcp_tools/openapi/protocols/tool_parser.py
@@ -6,5 +6,4 @@ from typing import Protocol, runtime_checkable
 
 @runtime_checkable
 class ToolParser(Protocol):
-
     def parse_tools(self) -> List[types.Tool]: ...

--- a/ansible_mcp_tools/openapi/spec_loaders.py
+++ b/ansible_mcp_tools/openapi/spec_loaders.py
@@ -13,7 +13,6 @@ logger = get_logger(__name__)
 
 
 class BaseLoader(SpecLoader, ABC):
-
     def __init__(self, url: str):
         self._url = url
 
@@ -36,10 +35,9 @@ class BaseLoader(SpecLoader, ABC):
 
 
 class FileLoader(BaseLoader):
-
     def __init__(self, url: str):
         if not url.lower().startswith("file://"):
-            raise RuntimeError(f"URL should begin with 'file://'.")
+            raise RuntimeError("URL should begin with 'file://'.")
         super().__init__(url)
 
     @override
@@ -53,7 +51,6 @@ class FileLoader(BaseLoader):
 
 
 class UrlLoader(BaseLoader):
-
     retries: int = 3
 
     @override

--- a/ansible_mcp_tools/openapi/tool_callers.py
+++ b/ansible_mcp_tools/openapi/tool_callers.py
@@ -21,7 +21,6 @@ logger = get_logger(__name__)
 
 
 class BaseToolCaller(ToolCaller, ABC):
-
     def __init__(
         self,
         spec: Dict,
@@ -36,7 +35,6 @@ class BaseToolCaller(ToolCaller, ABC):
 
 
 class DefaultToolCaller(BaseToolCaller):
-
     def __init__(
         self,
         spec: Dict,
@@ -197,8 +195,9 @@ class DefaultToolCaller(BaseToolCaller):
                 if method.lower() not in ["get", "post", "put", "delete", "patch"]:
                     continue
                 raw_name = f"{self._service_name}_{method.upper()} {path}"
-                current_function_name = self._tool_name_strategy.normalize_tool_name(
-                    raw_name
+                operation_id = operation.get("operationId", "")
+                current_function_name = utils.get_tool_name_from_operation_id(
+                    operation_id, raw_name, self._tool_name_strategy.normalize_tool_name
                 )
                 if current_function_name == function_name:
                     return {

--- a/ansible_mcp_tools/openapi/tool_name_strategies.py
+++ b/ansible_mcp_tools/openapi/tool_name_strategies.py
@@ -10,7 +10,6 @@ logger = get_logger(__name__)
 
 
 class DefaultToolNameStrategy(ToolNameStrategy):
-
     def normalize_tool_name(self, raw_name: str) -> str:
         """Convert an HTTP method and path into a normalized tool name."""
         try:

--- a/ansible_mcp_tools/openapi/tool_parsers.py
+++ b/ansible_mcp_tools/openapi/tool_parsers.py
@@ -9,11 +9,12 @@ from ansible_mcp_tools.openapi.protocols.tool_name_strategy import ToolNameStrat
 
 from mcp.server.fastmcp.utilities.logging import get_logger
 
+from ansible_mcp_tools import utils
+
 logger = get_logger(__name__)
 
 
 class BaseToolParser(ToolParser, ABC):
-
     def __init__(
         self, spec: Dict, service_name: str, tool_name_strategy: ToolNameStrategy
     ):
@@ -23,7 +24,6 @@ class BaseToolParser(ToolParser, ABC):
 
 
 class DefaultToolParser(BaseToolParser):
-
     def __init__(
         self, spec: Dict, service_name: str, tool_name_strategy: ToolNameStrategy
     ):
@@ -44,6 +44,7 @@ class DefaultToolParser(BaseToolParser):
             return tools
 
         logger.debug(f"Spec paths available: {list(self._spec['paths'].keys())}")
+        # version = self._spec.get("version", None)
         paths = {path: item for path, item in self._spec["paths"].items()}
         logger.debug(f"Paths: {list(paths.keys())}")
         for path, path_item in paths.items():
@@ -56,8 +57,11 @@ class DefaultToolParser(BaseToolParser):
                     continue
                 try:
                     raw_name = f"{self._service_name}_{method.upper()} {path}"
-                    function_name = self._tool_name_strategy.normalize_tool_name(
-                        raw_name
+                    operation_id = operation.get("operationId", "")
+                    function_name = utils.get_tool_name_from_operation_id(
+                        operation_id,
+                        raw_name,
+                        self._tool_name_strategy.normalize_tool_name,
                     )
 
                     tool_exists = False
@@ -70,10 +74,19 @@ class DefaultToolParser(BaseToolParser):
                     if tool_exists:
                         continue
 
-                    description = operation.get(
-                        "summary",
-                        operation.get("description", "No description available"),
-                    )
+                    description = operation.get("summary", "")
+                    if not description:
+                        description = operation.get("description", "")
+                        if description and "\n" in description:
+                            # take a max of tree lines
+                            description_lines = description.split("\n")
+                            description = "\n".join(
+                                description_lines[0 : min(3, len(description_lines))]
+                            )
+                            description = description.replace("\n", " ")
+                        if not description:
+                            description = operation_id or function_name
+
                     input_schema = {
                         "type": "object",
                         "properties": {},

--- a/ansible_mcp_tools/openapi/tool_parsers.py
+++ b/ansible_mcp_tools/openapi/tool_parsers.py
@@ -44,7 +44,7 @@ class DefaultToolParser(BaseToolParser):
             return tools
 
         logger.debug(f"Spec paths available: {list(self._spec['paths'].keys())}")
-        # version = self._spec.get("version", None)
+
         paths = {path: item for path, item in self._spec["paths"].items()}
         logger.debug(f"Paths: {list(paths.keys())}")
         for path, path_item in paths.items():

--- a/ansible_mcp_tools/sample_aap_tool.py
+++ b/ansible_mcp_tools/sample_aap_tool.py
@@ -34,7 +34,7 @@ async def fetch_aap_controller_jobs_list(
     auth_headers = get_authentication_headers()
     verify_cert = auth_user.authentication_info.verify_cert if auth_user else True
     server_url_path = utils.get_aap_service_url_path(
-        "controller", auth_user.authentication_info.header_name, "/api/v2/unified_jobs/"
+        "controller", auth_user.authentication_info.header_name, "/api/v2/jobs/"
     )
     async with httpx.AsyncClient(verify=verify_cert) as client:
         response = await client.get(

--- a/ansible_mcp_tools/utils.py
+++ b/ansible_mcp_tools/utils.py
@@ -34,6 +34,6 @@ def get_aap_service_url_path(
 def get_tool_name_from_operation_id(
     operation_id: str, raw_name: str, normalization_function: Callable[[str], str]
 ) -> str:
-    if operation_id and 0 < len(operation_id) <= 64:
+    if 0 < len(operation_id) <= 64:
         return operation_id
     return normalization_function(raw_name)

--- a/ansible_mcp_tools/utils.py
+++ b/ansible_mcp_tools/utils.py
@@ -1,3 +1,4 @@
+from typing import Callable
 from ansible_mcp_tools import registry
 
 AAP_JWT_HEADER_NAME = "X-DAB-JW-TOKEN"
@@ -28,3 +29,11 @@ def get_aap_service_url_path(
         path = path[1:]
 
     return f"{base_url_path}/{path}"
+
+
+def get_tool_name_from_operation_id(
+    operation_id: str, raw_name: str, normalization_function: Callable[[str], str]
+) -> str:
+    if operation_id and 0 < len(operation_id) <= 64:
+        return operation_id
+    return normalization_function(raw_name)


### PR DESCRIPTION

<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-47450
<!-- This PR does not need a corresponding Jira item. -->

## Description
use spec operatorId as tool_name when possible (the operatorId has length less or equal to 64, this is the majority of cases), when not possible use the normalization function.

fixes some linter problems using uvx check and format on the project.

## Testing
start the apps and use it llama-stack


### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [ ] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
