### PR TITLE
Add tools rules to register

### DIFF
--- a/aap_controller_api_2_5/server.py
+++ b/aap_controller_api_2_5/server.py
@@ -6,7 +6,7 @@ from ansible_mcp_tools.registry import register_service_url
 from ansible_mcp_tools.registry import init as init_registry
 from ansible_mcp_tools.server import LightspeedOpenAPIAAPServer
 from ansible_mcp_tools.openapi.spec_loaders import FileLoader
-
+from ansible_mcp_tools.openapi.tool_rules import MethodRule, NoDescriptionRule
 from ansible_mcp_tools.authentication import LightspeedAuthenticationBackend
 from ansible_mcp_tools.authentication.validators.aap_token_validator import (
     AAPTokenValidator,
@@ -48,6 +48,10 @@ mcp = LightspeedOpenAPIAAPServer(
         ]
     ),
     spec_loader=FileLoader(URL),
+    tool_rules=[
+        MethodRule(["PUT", "OPTIONS", "DELETE", "PATCH", "POST"]),
+        NoDescriptionRule(),
+    ],
     host=HOST,
     port=PORT,
 )

--- a/aap_gateway_api_2_5/server.py
+++ b/aap_gateway_api_2_5/server.py
@@ -7,6 +7,8 @@ from ansible_mcp_tools.registry import init as init_registry
 from ansible_mcp_tools.server import LightspeedOpenAPIAAPServer
 from ansible_mcp_tools.openapi.spec_loaders import FileLoader
 
+from ansible_mcp_tools.openapi.tool_rules import MethodRule, NoDescriptionRule
+
 from ansible_mcp_tools.authentication import LightspeedAuthenticationBackend
 from ansible_mcp_tools.authentication.validators.aap_token_validator import (
     AAPTokenValidator,
@@ -41,6 +43,10 @@ mcp = LightspeedOpenAPIAAPServer(
         ]
     ),
     spec_loader=FileLoader(URL),
+    tool_rules=[
+        MethodRule(["PUT", "OPTIONS", "DELETE", "PATCH", "POST"]),
+        NoDescriptionRule(),
+    ],
     host=HOST,
     port=PORT,
 )

--- a/aap_lightspeed_api_1_0/server.py
+++ b/aap_lightspeed_api_1_0/server.py
@@ -2,6 +2,11 @@ from os import environ
 
 from mcp.server.fastmcp.utilities.logging import get_logger
 
+from ansible_mcp_tools.openapi.tool_rules import (
+    MethodRule,
+    OperationIdBlackRule,
+    NoDescriptionRule,
+)
 from ansible_mcp_tools.registry import register_service_url
 from ansible_mcp_tools.registry import init as init_registry
 from ansible_mcp_tools.server import LightspeedOpenAPIAAPServer
@@ -48,6 +53,20 @@ mcp = LightspeedOpenAPIAAPServer(
         ]
     ),
     spec_loader=FileLoader(URL),
+    tool_rules=[
+        MethodRule(["PUT", "OPTIONS", "DELETE", "PATCH"]),
+        OperationIdBlackRule(
+            [
+                "ai_chat_create",
+                "ai_feedback_create",
+                "telemetry_settings_set",
+                "wca_api_key_set",
+                "wca_model_id_set",
+                "ai_completions_create",
+            ]
+        ),
+        NoDescriptionRule(),
+    ],
     host=HOST,
     port=PORT,
 )

--- a/ansible_mcp_tools/openapi/protocols/tool_rule.py
+++ b/ansible_mcp_tools/openapi/protocols/tool_rule.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ToolRule(Protocol):
+    # if include_any is True, any tool that pass the check will be included,
+    # this may be used in a whitelist rules
+    include_any: bool = False
+
+    def check(
+        self, path: str, method: str, method_operation: dict[str:Any]
+    ) -> bool: ...

--- a/ansible_mcp_tools/openapi/tool_rules.py
+++ b/ansible_mcp_tools/openapi/tool_rules.py
@@ -1,0 +1,83 @@
+from typing import Any
+
+from ansible_mcp_tools.openapi.protocols.tool_rule import ToolRule
+
+
+class MethodRule(ToolRule):
+    def __init__(
+        self,
+        black_list_methods: list[str],
+    ):
+        if not isinstance(black_list_methods, list):
+            black_list_methods = []
+
+        self._black_list_methods = list(
+            map(lambda item: item.lower(), black_list_methods)
+        )
+
+    def check(self, path: str, method: str, method_operation: dict[str:Any]) -> bool:
+        if method.lower() in self._black_list_methods:
+            return False
+        return True
+
+
+class OperationIdWhiteRule(ToolRule):
+    include_any = True
+
+    def __init__(self, white_list_operations: list[str]):
+        self._white_list_operations = white_list_operations
+
+    def check(self, path: str, method: str, method_operation: dict[str:Any]) -> bool:
+        operation_id = method_operation.get("operationId", "")
+        if operation_id in self._white_list_operations:
+            return True
+        return False
+
+
+class OperationIdBlackRule(ToolRule):
+    def __init__(self, black_list: list[str]):
+        self._black_list = black_list
+
+    def check(self, path: str, method: str, method_operation: dict[str:Any]) -> bool:
+        operation_id = method_operation.get("operationId", "")
+        if operation_id in self._black_list:
+            return False
+        return True
+
+
+class PathRule(ToolRule):
+    def __init__(self, black_list_paths: list[str]):
+        self._black_list_paths = black_list_paths
+
+    def check(self, path: str, method: str, method_operation: dict[str:Any]) -> bool:
+        if path in self._black_list_paths:
+            return False
+        return True
+
+
+class NoDescriptionRule(ToolRule):
+    def check(self, path: str, method: str, method_operation: dict[str:Any]) -> bool:
+        if not method_operation.get("description", "") and not method_operation.get(
+            "summary", ""
+        ):
+            return False
+        return True
+
+
+def check_tool_rules(
+    tool_rules: list[ToolRule], path: str, method: str, method_operation: dict[str:Any]
+) -> bool:
+    valid = True
+    for tool_rule in tool_rules:
+        check = tool_rule.check(path, method, method_operation)
+        if tool_rule.include_any:
+            if check:
+                valid = True
+                break
+        else:
+            if not check:
+                valid = False
+                # do not break to check all the rules,
+                # because maybe a white rule with include_any True is ahead of the list
+
+    return valid

--- a/ansible_mcp_tools/server.py
+++ b/ansible_mcp_tools/server.py
@@ -6,6 +6,8 @@ from ansible_mcp_tools.authentication.middleware import (
 )
 from ansible_mcp_tools.openapi.protocols.spec_loader import SpecLoader
 from ansible_mcp_tools.openapi.protocols.tool_name_strategy import ToolNameStrategy
+from ansible_mcp_tools.openapi.protocols.tool_rule import ToolRule
+
 from ansible_mcp_tools.openapi.tool_parsers import DefaultToolParser
 from ansible_mcp_tools.openapi.tool_callers import DefaultToolCaller
 from ansible_mcp_tools.openapi.tool_name_strategies import DefaultToolNameStrategy
@@ -61,6 +63,7 @@ class LightspeedOpenAPIAAPServer(LightspeedBaseAAPServer):
         auth_backend: AuthenticationBackend | None,
         spec_loader: SpecLoader,
         tool_name_strategy: ToolNameStrategy | None = None,
+        tool_rules: list[ToolRule] | None = None,
         **settings: Any,
     ):
         super().__init__(name, auth_backend, **settings)
@@ -68,7 +71,9 @@ class LightspeedOpenAPIAAPServer(LightspeedBaseAAPServer):
         _tool_name_strategy = (
             tool_name_strategy if tool_name_strategy else DefaultToolNameStrategy()
         )
-        _tool_parser = DefaultToolParser(_spec, service_name, _tool_name_strategy)
+        _tool_parser = DefaultToolParser(
+            _spec, service_name, _tool_name_strategy, tool_rules=tool_rules
+        )
         self._tools = _tool_parser.parse_tools()
         self._tool_caller = DefaultToolCaller(
             _spec, self._tools, service_name, _tool_name_strategy


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-48551
<!-- This PR does not need a corresponding Jira item. -->

## Description
Add a rules class to customize wich tools to include from the openapi spec 

when running mcp controller removed 664 tools with the default used rules
```
                    DEBUG    Registered 321 functions from   tool_parsers.py:179
                             OpenAPI spec.                                      
                    DEBUG    Ignored 664 functions from      tool_parsers.py:180
                             OpenAPI spec.          
```

when running mcp gateway removed 115 tools with the default used rules
```
 DEBUG    Registered 72 functions from    tool_parsers.py:179
                             OpenAPI spec.                                      
                    DEBUG    Ignored 115 functions from      tool_parsers.py:180
                             OpenAPI spec.   
```

when running mcp lightspeed removed 10 tools with the default used rules
```
                    DEBUG    Registered 16 functions from    tool_parsers.py:179
                             OpenAPI spec.                                      
                    DEBUG    Ignored 10 functions from       tool_parsers.py:180
                             OpenAPI spec. 

```

a Black list rule is a rule with include_any False , all black list rules has to pass to include a tool
a White list rule is a rule with include_any True, if a tool pass any of the while list rules  it will be included, even if one or many black list rules failed.   



### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
