### PR TITLE
Fixes mcp openapi default version in path

### DIFF
--- a/ansible_mcp_tools/authentication/validators/aap_base_validator.py
+++ b/ansible_mcp_tools/authentication/validators/aap_base_validator.py
@@ -44,10 +44,11 @@ class AAPBaseValidator(AuthenticationValidator):
             return None
         url = urljoin(self._authentication_server_url, "api/gateway/v1/me/")
         logger.debug("calling authentication server at url: %s", url)
+        headers = {self.AUTHENTICATION_HEADER_NAME: authentication_header_value}
         async with httpx.AsyncClient(verify=self._verify_cert) as client:
             response = await client.get(
                 url=url,
-                headers=dict(Authorization=authentication_header_value),
+                headers=headers,
             )
             if not response.is_success:
                 logger.error(

--- a/ansible_mcp_tools/openapi/common.py
+++ b/ansible_mcp_tools/openapi/common.py
@@ -1,0 +1,25 @@
+import re
+from typing import Any
+
+DEFAULT_VERSION_MATCH: str = "^v[1-9]+"
+
+DEFAULT_VERSION_PARAM_NAME: str = "version"
+
+
+def get_spec_default_version(spec: dict[str, Any]) -> str | None:
+    version: str | None = None
+    info_version: str | None = spec.get("info", {}).get("version", None)
+    if info_version and re.match(DEFAULT_VERSION_MATCH, info_version):
+        version = info_version
+    return version
+
+
+def get_spec_path_with_version(
+    path: str, version: str, version_param_name=DEFAULT_VERSION_PARAM_NAME
+) -> (str, bool):
+    ignore_version_path_param = False
+    version_in_path_string = "{" + version_param_name + "}"
+    if version and version_in_path_string in path:
+        path = path.replace(version_in_path_string, version)
+        ignore_version_path_param = True
+    return path, ignore_version_path_param


### PR DESCRIPTION

<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: https://issues.redhat.com/browse/AAP-50669
<!-- This PR does not need a corresponding Jira item. -->

## Description
Fixes mcp openapi default version in path, the LLM may have some troubles guessing the
 right version to use for the path resolution hopefully some openapi schemas provide the default version to use.


### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->

direct client to ansible-chatbot-stack -> mcp servers
via wisdom-service to ansible-chatbot-stack -> mcp servers

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
